### PR TITLE
fix: add semantic highlighting for outdated language highlighters

### DIFF
--- a/themes/cika-black-dark-color-theme.json
+++ b/themes/cika-black-dark-color-theme.json
@@ -1,6 +1,7 @@
 {
   "name": "Cika",
   "type": "dark",
+  "semanticHighlighting": true,
   "colors": {
     //
     "foreground": "#aaa",
@@ -54,7 +55,7 @@
     "statusBar.noFolderBackground": "#000",
     "dropdown.background": "#000",
     "input.background": "#000",
-    "tab.activeBackground": "#000",
+    "tab.activeBackground": "#000"
     //
   },
   "tokenColors": [
@@ -64,7 +65,7 @@
         "string.comment",
         "punctuation.definition.comment",
         "string.quoted.docstring.multi",
-        "string.quoted.docstring.multi storage.type.string",
+        "string.quoted.docstring.multi storage.type.string"
       ],
       "settings": {
         "foreground": "#5c6370",
@@ -80,7 +81,7 @@
         "punctuation.definition.template-expression.end.ts",
         "string.template.js",
         "meta.template.expression.js",
-        "string.embedded",
+        "string.embedded"
       ],
       "settings": {
         "foreground": "#98c379"
@@ -102,7 +103,7 @@
         "keyword",
         "keyword.operator.logical",
         "keyword.operator.constructor",
-        "storage",
+        "storage"
       ],
       "settings": {
         "foreground": "#FFD14A"
@@ -159,7 +160,7 @@
     {
       "scope": "variable.parameter",
       "settings": {
-        "fontStyle": "italic",
+        "fontStyle": "italic"
         // "foreground": "#d19a66"
       }
     },
@@ -169,7 +170,7 @@
       "scope": [
         "source.json",
         "support.dictionary.json",
-        "support.type.property-name.json",
+        "support.type.property-name.json"
       ],
       "settings": {
         "foreground": "#ddd"
@@ -191,9 +192,7 @@
     // HTML ----------------------------------------------------------------------
     {
       "name": "[HTML] - Entity",
-      "scope": [
-        "entity.other"
-      ],
+      "scope": ["entity.other"],
       "settings": {
         "foreground": "#8df"
       }
@@ -213,10 +212,7 @@
     },
     {
       "name": "[HTML] - Keywords",
-      "scope": [
-        "punctuation.definition.keyword",
-        "keyword.control"
-      ],
+      "scope": ["punctuation.definition.keyword", "keyword.control"],
       "settings": {
         "foreground": "#FFD14A"
       }
@@ -230,10 +226,7 @@
     },
     {
       "name": "[HTML] - Meta tags",
-      "scope": [
-        "meta.tag.block.any.html",
-        "meta.tag.inline.any.html"
-      ],
+      "scope": ["meta.tag.block.any.html", "meta.tag.inline.any.html"],
       "settings": {
         "foreground": "#00AEFF"
       }
@@ -277,18 +270,14 @@
     },
     {
       "name": "[CSS] - Hex hex",
-      "scope": [
-        "punctuation.definition.constant.css"
-      ],
+      "scope": ["punctuation.definition.constant.css"],
       "settings": {
         "foreground": "#a8f"
       }
     },
     {
       "name": "[CSS] - keys",
-      "scope": [
-        "support.type.property-name.css"
-      ],
+      "scope": ["support.type.property-name.css"],
       "settings": {
         "foreground": "#ddd"
       }
@@ -312,36 +301,28 @@
     },
     {
       "name": "[CSS] - Punctiation",
-      "scope": [
-        "punctuation.definition.entity.css"
-      ],
+      "scope": ["punctuation.definition.entity.css"],
       "settings": {
         "foreground": "#00AEFF"
       }
     },
     {
       "name": "[CSS] - ID hastags",
-      "scope": [
-        "entity.other.attribute-name.pseudo-element.css"
-      ],
+      "scope": ["entity.other.attribute-name.pseudo-element.css"],
       "settings": {
         "foreground": "#00AEFF"
       }
     },
     {
       "name": "[CSS] - support misc function",
-      "scope": [
-        "support.function.misc.scss"
-      ],
+      "scope": ["support.function.misc.scss"],
       "settings": {
         "foreground": "#a8f"
       }
     },
     {
       "name": "[CSS] - ID Selector",
-      "scope": [
-        "entity.other.attribute-name.id.css"
-      ],
+      "scope": ["entity.other.attribute-name.id.css"],
       "settings": {
         "foreground": "#8df"
       }
@@ -366,19 +347,14 @@
     },
     {
       "name": "[CSS] - Constant",
-      "scope": [
-        "source.stylus constant",
-        "source.css constant"
-      ],
+      "scope": ["source.stylus constant", "source.css constant"],
       "settings": {
         "foreground": "#a8f"
       }
     },
     {
       "name": "[CSS] - support constant",
-      "scope": [
-        "support.constant.property-value.css"
-      ],
+      "scope": ["support.constant.property-value.css"],
       "settings": {
         "foreground": "#FFD14A"
       }
@@ -415,14 +391,11 @@
     },
     {
       "name": "[CSS] - Variable",
-      "scope": [
-        "source.css variable",
-        "source.stylus variable"
-      ],
+      "scope": ["source.css variable", "source.stylus variable"],
       "settings": {
         "foreground": "#FFD14A"
       }
-    },
+    }
     // ----------------------------------------------------------------------
   ]
 }

--- a/themes/cika-blue-dark-color-theme.json
+++ b/themes/cika-blue-dark-color-theme.json
@@ -1,5 +1,6 @@
 {
   "name": "Cika",
+  "semanticHighlighting": true,
   "colors": {
     //
     "editor.background": "#000",
@@ -56,7 +57,7 @@
     "badge.foreground": "#43B9D8",
     //
     "tab.activeForeground": "#43B9D8",
-    "foreground": "#43B9D8",
+    "foreground": "#43B9D8"
     //
   },
   "tokenColors": [
@@ -66,7 +67,7 @@
         "string.comment",
         "punctuation.definition.comment",
         "string.quoted.docstring.multi",
-        "string.quoted.docstring.multi storage.type.string",
+        "string.quoted.docstring.multi storage.type.string"
       ],
       "settings": {
         "foreground": "#5c6370",
@@ -74,60 +75,43 @@
       }
     },
     {
-      "scope": [
-        "string",
-      ],
+      "scope": ["string"],
       "settings": {
         "foreground": "#43B9D8"
       }
     },
     {
-      "scope": [
-        "storage",
-      ],
+      "scope": ["storage"],
       "settings": {
         "foreground": "#0099ff"
       }
     },
     {
-      "scope": [
-        "keyword",
-        "constant",
-        "variable.language"
-      ],
+      "scope": ["keyword", "constant", "variable.language"],
       "settings": {
         "foreground": "#f6b"
       }
     },
     {
-      "scope": [
-        "entity",
-        "support",
-      ],
+      "scope": ["entity", "support"],
       "settings": {
         "foreground": "#4ec7ff"
       }
     },
     {
-      "scope": [
-        "variable.language",
-      ],
+      "scope": ["variable.language"],
       "settings": {
         "foreground": "#00ffea94"
       }
     },
     {
-      "scope": [
-        "variable.parameter",
-      ],
+      "scope": ["variable.parameter"],
       "settings": {
         "fontStyle": "italic"
       }
     },
     {
-      "scope": [
-        "meta.function-call.object",
-      ],
+      "scope": ["meta.function-call.object"],
       "settings": {
         "fontStyle": "underline"
       }
@@ -150,7 +134,7 @@
       "scope": [
         "source.json",
         "support.dictionary.json",
-        "support.type.property-name.json",
+        "support.type.property-name.json"
       ],
       "settings": {
         "foreground": "#fff"
@@ -170,9 +154,7 @@
     },
     // HTML ----------------------------------------------------------------------
     {
-      "scope": [
-        "entity.other"
-      ],
+      "scope": ["entity.other"],
       "settings": {
         "foreground": "#8df"
       }
@@ -209,14 +191,14 @@
         "source.css support.constant"
       ],
       "settings": {
-        "foreground": "#ddd",
+        "foreground": "#ddd"
       }
     },
     {
       "scope": [
         "source.css punctuation.definition.keyword",
         "source.css keyword.control",
-        "keyword.other.important.scss",
+        "keyword.other.important.scss"
       ],
       "settings": {
         "foreground": "#f6b"
@@ -227,7 +209,7 @@
         "entity.other.attribute-name.id.css",
         "entity.other.attribute-name.pseudo-element.css",
         "punctuation.definition.entity.css",
-        "entity.name.tag.css",
+        "entity.name.tag.css"
       ],
       "settings": {
         "foreground": "#8df"
@@ -251,7 +233,7 @@
         "source.stylus constant",
         "source.css constant",
         "support.function.misc.scss",
-        "punctuation.definition.constant.css",
+        "punctuation.definition.constant.css"
       ],
       "settings": {
         "foreground": "#a8f"
@@ -267,6 +249,6 @@
       "settings": {
         "foreground": "#98c379"
       }
-    },
+    }
   ]
 }

--- a/themes/cika-purple-dark-color-theme.json
+++ b/themes/cika-purple-dark-color-theme.json
@@ -1,6 +1,7 @@
 {
 	"name": "Cika Purple",
 	"type": "dark",
+	"semanticHighlighting": true,
 	"colors": {
 		// bg1 #07000c bg2 #160029 bg3 #240043
 		//

--- a/themes/cika-red-dark-color-theme.json
+++ b/themes/cika-red-dark-color-theme.json
@@ -1,6 +1,7 @@
 {
 	"name": "Cika Red",
 	"type": "dark",
+	"semanticHighlighting": true,
 	"colors": {
 		// bg1 #0c0000 bg2 #200000 bg3 #41000
 		// fg2 ff0000


### PR DESCRIPTION
This resolves an issue where languages such as Python had no highlighting for new statements, and little highlighting for attributes/methods/variables/constants as python is dynamic.
